### PR TITLE
Enable preview URLs and Workers observability

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,4 +8,8 @@
     "binding": "ASSETS",
   },
   "routes": [{ "pattern": "nywebperf.com", "custom_domain": true }],
+  "preview_urls": true,
+  "observability": {
+    "enabled": true,
+  },
 }


### PR DESCRIPTION
## Summary
- `preview_urls: true` — Cloudflare assigns a preview URL per uploaded version; the Cloudflare GitHub app posts it on the PR.
- `observability.enabled: true` — turns on Workers Logs so request traces show up in the dashboard.

This PR itself should trigger the first preview URL comment once Cloudflare Builds picks it up.

## Test plan
- [ ] Cloudflare GitHub app posts a preview URL on this PR
- [ ] Visit the preview URL and confirm `/meetup` still redirects (exact-match rule)
- [ ] Confirm `/e/12345` redirects via the new route pattern
- [ ] After merge, confirm Workers Logs in the Cloudflare dashboard are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)