### PR TITLE
Expose Worker on the *.workers.dev subdomain

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,4 +8,5 @@
     "binding": "ASSETS",
   },
   "routes": [{ "pattern": "nywebperf.com", "custom_domain": true }],
+  "workers_dev": true,
 }


### PR DESCRIPTION
## Summary
- `workers_dev: true` adds the `nywebperf-com.<subdomain>.workers.dev` host alongside the `nywebperf.com` custom domain, giving a stable URL for testing without DNS.

## Test plan
- [ ] After deploy, `nywebperf-com.<subdomain>.workers.dev/meetup` redirects like the apex
- [ ] `nywebperf.com/meetup` continues to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)